### PR TITLE
[16.0][IMP] account_ecotax: improvements

### DIFF
--- a/account_ecotax/__manifest__.py
+++ b/account_ecotax/__manifest__.py
@@ -27,6 +27,7 @@
         "views/product_template_view.xml",
         "views/product_view.xml",
         "views/account_tax_view.xml",
+        "views/report_invoice.xml",
     ],
     "installable": True,
 }

--- a/account_ecotax/models/account_move.py
+++ b/account_ecotax/models/account_move.py
@@ -2,8 +2,7 @@
 #   @author Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, fields, models
-from odoo.tools.misc import formatLang
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
@@ -21,41 +20,21 @@ class AccountMove(models.Model):
         for move in self:
             move.amount_ecotax = sum(move.line_ids.mapped("subtotal_ecotax"))
 
-    @api.model
-    def _get_tax_totals(
-        self, partner, tax_lines_data, amount_total, amount_untaxed, currency
-    ):
-        """Include Ecotax when this method is called upon a single invoice
-
-        NB: `_get_tax_totals()` is called when field `tax_totals_json` is
-        computed, which is used in invoice form view to display taxes and
-        totals.
-        """
-        res = super()._get_tax_totals(
-            partner, tax_lines_data, amount_total, amount_untaxed, currency
-        )
-        if len(self) != 1:
-            return res
-
-        base_amt = self.amount_total
-        ecotax_amt = self.amount_ecotax
-        if not ecotax_amt:
-            return res
-
-        env = self.with_context(lang=partner.lang).env
-        fmt_ecotax_amt = formatLang(env, ecotax_amt, currency_obj=currency)
-        fmt_base_amt = formatLang(env, base_amt, currency_obj=currency)
-        data = list(res["groups_by_subtotal"].get(_("Untaxed Amount")) or [])
-        data.append(
-            {
-                "tax_group_name": _("Included Ecotax"),
-                "tax_group_amount": ecotax_amt,
-                "formatted_tax_group_amount": fmt_ecotax_amt,
-                "tax_group_base_amount": base_amt,
-                "formatted_tax_group_base_amount": fmt_base_amt,
-                "tax_group_id": False,  # Not an actual tax
-                "group_key": "Included Ecotax",
-            }
-        )
-        res["groups_by_subtotal"][_("Untaxed Amount")] = data
-        return res
+    # copy dependencies of the original method
+    @api.depends_context("lang")
+    @api.depends(
+        "invoice_line_ids.currency_rate",
+        "invoice_line_ids.tax_base_amount",
+        "invoice_line_ids.tax_line_id",
+        "invoice_line_ids.price_total",
+        "invoice_line_ids.price_subtotal",
+        "invoice_payment_term_id",
+        "partner_id",
+        "currency_id",
+    )
+    def _compute_tax_totals(self):
+        """We will include ecotax in totals computation only
+        if this method is called upon a single invoice"""
+        if len(self) == 1:
+            self = self.with_context(move_id=self.id)
+        return super()._compute_tax_totals()

--- a/account_ecotax/models/account_tax.py
+++ b/account_ecotax/models/account_tax.py
@@ -28,5 +28,5 @@ class AccountTax(models.Model):
 # partner: res.partner object or None
 # for weight based ecotax
 # result = product.weight_based_ecotax or 0.0
-result = product.fixed_ecotax or 0.0
+result = (product.fixed_ecotax or 0.0) * quantity
             """

--- a/account_ecotax/models/account_tax.py
+++ b/account_ecotax/models/account_tax.py
@@ -2,7 +2,8 @@
 #   @author Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.tools.misc import formatLang
 
 
 class AccountTax(models.Model):
@@ -30,3 +31,46 @@ class AccountTax(models.Model):
 # result = product.weight_based_ecotax or 0.0
 result = (product.fixed_ecotax or 0.0) * quantity
             """
+
+    @api.model
+    def _prepare_tax_totals(
+        self, base_lines, currency, tax_lines=None
+    ):
+        """Include Ecotax when this method is called upon a single invoice
+        NB: `_prepare_tax_totals()` is called when field `_compute_tax_totals` is
+        computed, which is used in invoice form view to display taxes and
+        totals.
+        """
+        res = super()._prepare_tax_totals(
+            base_lines,
+            currency,
+            tax_lines=tax_lines
+        )
+
+        move_id = self.env.context.get("move_id", False)
+        if not move_id:
+            return res
+
+        move = self.env["account.move"].browse(move_id)
+        base_amt = move.amount_total
+        ecotax_amt = move.amount_ecotax
+        if not ecotax_amt:
+            return res
+
+        fmt_ecotax_amt = formatLang(self.env, ecotax_amt, currency_obj=currency)
+        fmt_base_amt = formatLang(self.env, base_amt, currency_obj=currency)
+        data = list(res["groups_by_subtotal"].get(_("Untaxed Amount")) or [])
+        data.append(
+            {
+                "tax_group_name": _("Included Ecotax"),
+                "tax_group_amount": ecotax_amt,
+                "formatted_tax_group_amount": fmt_ecotax_amt,
+                "tax_group_base_amount": base_amt,
+                "formatted_tax_group_base_amount": fmt_base_amt,
+                "tax_group_id": False,  # Not an actual tax
+                "group_key": "Included Ecotax",
+                "hide_base_amount": True
+            }
+        )
+        res["groups_by_subtotal"][_("Untaxed Amount")] = data
+        return res

--- a/account_ecotax/views/report_invoice.xml
+++ b/account_ecotax/views/report_invoice.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document_inherit_ecotax" inherit_id="account.report_invoice_document">
+        <xpath expr="//th[@name='th_taxes']" position="after">
+            <th name="th_subtotal_ecotax" class="text-end"><span>Ecotax</span></th>
+        </xpath>
+        <xpath expr="//td[@name='td_taxes']" position="after">
+            <td class="text-end">
+                <span t-field="line.subtotal_ecotax" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
+            </td>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This change ensures that ecotax classifications are automatically applied from the associated product ecotax lines when creating  invoices from sale orders.

### **Result**
![Screenshot from 2024-10-02 13-04-26](https://github.com/user-attachments/assets/b579cf68-99a9-4a15-830a-ba750767edab)

![image](https://github.com/user-attachments/assets/adf3ffe1-fc86-47a3-832a-065db148f536)

![image](https://github.com/user-attachments/assets/967e86fc-c608-40a0-ab69-838d1f276874)
